### PR TITLE
issue34, work around for setuptools > 57.50

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(name=PACKAGENAME,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
+      use_2to3=False,
       entry_points=entry_points,
       **package_info
 )


### PR DESCRIPTION
For setuptools > 57.50, 2to3 is no longer supported.
Changed the value of use_2to3 in setup.py from True to False as a workaround.

setup(name=PACKAGENAME,
      version=VERSION,
      description=DESCRIPTION,
      scripts=scripts,
      install_requires=REQUIREMENTS,
      author=AUTHOR,
      author_email=AUTHOR_EMAIL,
      license=LICENSE,
      url=URL,
      long_description=LONG_DESCRIPTION,
      cmdclass=cmdclassd,
      zip_safe=False,
      use_2to3=False,  # change this from `True` to `False`
      entry_points=entry_points,
      **package_info
)